### PR TITLE
bump staleDuration so old data is retained for longer

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,7 +23,7 @@ type Metrics struct {
 
 // CreateMetrics - creates the "Metrics" control object
 func CreateMetrics() Metrics {
-	staleDuration := (5 * time.Minute)
+	staleDuration := (15 * time.Minute)
 	redisService, redisExists := redisServiceAvailable()
 	if redisExists {
 		redisClient, _ := createRedisClient(redisService)


### PR DESCRIPTION
## WHAT
We found that the data in the cache isn't retained for long enough to provide complete metrics for all cells.
This change is just to extend the timeout before data in the cache is killed and gets refreshed

## HOW TO REVIEW
Push in your env and see if it works
Obvs run the tests to make sure I didn't break anything