### PR TITLE
Adding support for setting the stack in a cf push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ If we had 50 Diego Cells
 `WATERMARK: 10%` - Watermark count = `5`
 `WATERMARK: 10` - Watermark count = `10`
 
+#### cf cli version
+
+With the inclusion of stack support in the cf push you will need to be using v6.39.1 or newer of the cf cli.
+
 #### Manual deployment
 
 ```
@@ -103,12 +107,9 @@ CF_API_ENDPOINT=https://api.system.domain.cf \
 CF_USERNAME=cf_firehose_username \
 CF_PASSWORD=cf_firehose_password \
 APP_NAME=my_diego_capacity_monitoring_app \
+STACK=cflinuxfs2 \
 ./deploy.sh
 ```
-
-### Development
-
-Currently, this repo should be manually cloned into `$GOPATH/src/github.com/FidelityInternational/diego-capacity-monitor`as the Godeps.json file has FidelityInternational github.com import path set (which will be used when we open source this project).
 
 ### Testing
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,14 +20,14 @@ if [[ "$(cf service cache || true)" == *"FAILED"* ]] ; then
   cf create-service p-redis shared-vm cache || true
 fi
 if [[ "$(cf app "${APP_NAME:-diego-capacity-monitor}") || true)" == *"FAILED"* ]] ; then
-  cf push "${APP_NAME:-diego-capacity-monitor}" --no-start
+  cf push "${APP_NAME:-diego-capacity-monitor}" --no-start -s "${STACK:-cflinuxfs2}"
   setEnvs "${APP_NAME:-diego-capacity-monitor}"
   cf bind-service "${APP_NAME:-diego-capacity-monitor}" cache || true
   cf start "${APP_NAME:-diego-capacity-monitor}"
 else
   echo "Zero downtime deploying..."
   domain=$(cf app "${APP_NAME:-diego-capacity-monitor}" | grep -E 'urls|routes' | cut -d":" -f2 | xargs | cut -d"." -f 2-)
-  cf push "${APP_NAME:-diego-capacity-monitor}-green" -f manifest.yml -n "${APP_NAME:-diego-capacity-monitor}-green" --no-start
+  cf push "${APP_NAME:-diego-capacity-monitor}-green" -f manifest.yml -s "${STACK:-cflinuxfs2}" -n "${APP_NAME:-diego-capacity-monitor}-green" --no-start
   setEnvs "${APP_NAME:-diego-capacity-monitor}-green"
   cf bind-service "${APP_NAME:-diego-capacity-monitor}-green" cache || true
   cf start "${APP_NAME:-diego-capacity-monitor}-green"


### PR DESCRIPTION
- This is required to allow testing of the changes from cflinuxfs2 to cflinuxfs3 with the upcoming cf upgrades.
- Add comment about minimum cf cli level on readme
- remove irrelevant comment about location from readme